### PR TITLE
ES-39873:- use open sans as default font

### DIFF
--- a/components/_globals.scss
+++ b/components/_globals.scss
@@ -15,7 +15,7 @@ $color-accent-contrast: $color-dark-contrast !default;
 $unit: 1rem !default;
 
 // -- Fonts
-$preferred-font: "Roboto", "Helvetica", "Arial", sans-serif !default;
+$preferred-font: "Open Sans", "Helvetica", "Arial", sans-serif !default;
 $font-size: 1.6 * $unit !default;
 $font-size-tiny: 1.2 * $unit !default;
 $font-size-small: 1.4 * $unit !default;

--- a/lib/_globals.scss
+++ b/lib/_globals.scss
@@ -15,7 +15,7 @@ $color-accent-contrast: $color-dark-contrast !default;
 $unit: 1rem !default;
 
 // -- Fonts
-$preferred-font: "Roboto", "Helvetica", "Arial", sans-serif !default;
+$preferred-font: "Open Sans", "Helvetica", "Arial", sans-serif !default;
 $font-size: 1.6 * $unit !default;
 $font-size-tiny: 1.2 * $unit !default;
 $font-size-small: 1.4 * $unit !default;


### PR DESCRIPTION
ES-39873

React toolbox default font is roboto, earlier we were overwriting font-family in dashboard in multiple places. This pr sets the font directly in react-toolbox instead.