### PR TITLE
ES-39872: use noto sans display as default font

### DIFF
--- a/components/_globals.scss
+++ b/components/_globals.scss
@@ -15,7 +15,7 @@ $color-accent-contrast: $color-dark-contrast !default;
 $unit: 1rem !default;
 
 // -- Fonts
-$preferred-font: "Noto Sans", "Helvetica", "Arial", sans-serif !default;
+$preferred-font: "Noto Sans Display", "Helvetica", "Arial", sans-serif !default;
 $font-size: 1.6 * $unit !default;
 $font-size-tiny: 1.2 * $unit !default;
 $font-size-small: 1.4 * $unit !default;

--- a/lib/_globals.scss
+++ b/lib/_globals.scss
@@ -15,7 +15,7 @@ $color-accent-contrast: $color-dark-contrast !default;
 $unit: 1rem !default;
 
 // -- Fonts
-$preferred-font: "Noto Sans", "Helvetica", "Arial", sans-serif !default;
+$preferred-font: "Noto Sans Display", "Helvetica", "Arial", sans-serif !default;
 $font-size: 1.6 * $unit !default;
 $font-size-tiny: 1.2 * $unit !default;
 $font-size-small: 1.4 * $unit !default;


### PR DESCRIPTION
ES-39872

we have open sans as the default font, this pr moves it to noto sans.