### PR TITLE
ES-46854  - Remove hot loader

### DIFF
--- a/components/utils/react.js
+++ b/components/utils/react.js
@@ -1,5 +1,3 @@
-import { areComponentsEqual } from 'react-hot-loader';
-
 export function isComponentOfType (classType, reactElement) {
-  return areComponentsEqual(reactElement.type, classType);
+  return reactElement.type === classType;
 }

--- a/lib/utils/react.js
+++ b/lib/utils/react.js
@@ -4,9 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.isComponentOfType = isComponentOfType;
-
-var _reactHotLoader = require('react-hot-loader');
-
 function isComponentOfType(classType, reactElement) {
-  return (0, _reactHotLoader.areComponentsEqual)(reactElement.type, classType);
+  return reactElement.type === classType;
 }

--- a/package.json
+++ b/package.json
@@ -119,8 +119,7 @@
   "license": "MIT",
   "peerDependencies": {
     "react": "^0.14 || ~15.4.0 || ^16.5.1",
-    "react-dom": "^0.14.0 || ~15.4.0 || ^16.5.1",
-    "react-hot-loader": "^4.12.19"
+    "react-dom": "^0.14.0 || ~15.4.0 || ^16.5.1"
   },
   "pre-commit": "lint:staged"
 }


### PR DESCRIPTION
Removed react hot loader dependency as we are moving to fast-refresh instead react hot loader.

`areComponentsEqual` function is used currently since the react hot loader proxies all the components so in order to check the component reference check we used the util. Now the react hot loader is removed that function is not useful. So removed.


REf PR - https://github.com/locus-taxy/locus-dashboard-v2/pull/4893