### PR TITLE
version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-toolbox",
   "description": "A set of React components implementing Google's Material Design specification with the power of CSS Modules.",
   "homepage": "http://www.react-toolbox.io",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "main": "./lib",
   "author": {
     "name": "React Toolbox Team",


### PR DESCRIPTION
Failed to bump version in the previous [PR](https://github.com/locus-taxy/react-toolbox/pull/10) related to the hot-module loader removal.